### PR TITLE
Volume changing in SDL

### DIFF
--- a/src/client/main-sdl.c
+++ b/src/client/main-sdl.c
@@ -55,6 +55,9 @@ static bool nicegfx = false;
 /* Want window borders? */
 static bool windowborders = true;
 
+/* Sound volume */
+static int volume = 50;
+
 static int overdraw = 0;
 static int overdraw_max = 0;
 
@@ -270,6 +273,11 @@ static int MoreHeightPlus;  /* Increase tile height */
 static int MoreHeightMinus; /* Decrease tile height */
 static int *GfxButtons;     /* Graphics mode buttons */
 static int SelectedGfx;     /* Current selected gfx */
+
+#ifdef SOUND_SDL
+    static int MoreVolumePlus;  /* Increase game volume */
+    static int MoreVolumeMinus; /* Decrease game volume */
+#endif
 
 
 /*
@@ -1593,6 +1601,13 @@ static void FontSizeChange(sdl_Button *sender)
 }
 
 
+static void VolumeChange(sdl_Button *sender)
+{
+    volume += sender->tag;
+    volume = set_volume(volume);
+}
+
+
 static void MoreDraw(sdl_Window *win)
 {
     term_window *window = &windows[SelectedTerm];
@@ -1621,6 +1636,24 @@ static void MoreDraw(sdl_Window *win)
 
     button = sdl_ButtonBankGet(&win->buttons, MoreHeightPlus);
     sdl_ButtonVisible(button, SelectedGfx? true: false);
+
+#ifdef SOUND_SDL
+    button = sdl_ButtonBankGet(&win->buttons, MoreVolumePlus);
+    sdl_ButtonVisible(button, SelectedGfx? true: false);
+
+    button = sdl_ButtonBankGet(&win->buttons, MoreVolumeMinus);
+    sdl_ButtonVisible(button, SelectedGfx? true: false);
+
+
+    sdl_WindowText(win, colour, 20, y, format("Volume is %d.", volume));
+    button = sdl_ButtonBankGet(&win->buttons, MoreVolumeMinus);
+    sdl_ButtonMove(button, 150, y);
+
+    button = sdl_ButtonBankGet(&win->buttons, MoreVolumePlus);
+    sdl_ButtonMove(button, 180, y);
+
+    y += 20;
+#endif
 
     if (SelectedGfx)
     {
@@ -1786,6 +1819,30 @@ static void MoreActivate(sdl_Button *sender)
     button->tag = -1;
     sdl_ButtonVisible(button, SelectedGfx? true: false);
     button->activate = HeightChange;
+
+#ifdef SOUND_SDL
+    MoreVolumePlus = sdl_ButtonBankNew(&PopUp.buttons);
+    button = sdl_ButtonBankGet(&PopUp.buttons, MoreVolumePlus);
+
+    button->unsel_colour = ucolour;
+    button->sel_colour = scolour;
+    sdl_ButtonSize(button, 20, PopUp.font.height + 2);
+    sdl_ButtonCaption(button, "+");
+    button->tag = 5;
+    sdl_ButtonVisible(button, SelectedGfx? true: false);
+    button->activate = VolumeChange;
+
+    MoreVolumeMinus = sdl_ButtonBankNew(&PopUp.buttons);
+    button = sdl_ButtonBankGet(&PopUp.buttons, MoreVolumeMinus);
+
+    button->unsel_colour = ucolour;
+    button->sel_colour = scolour;
+    sdl_ButtonSize(button, 20, PopUp.font.height + 2);
+    sdl_ButtonCaption(button, "-");
+    button->tag = -5;
+    sdl_ButtonVisible(button, SelectedGfx? true: false);
+    button->activate = VolumeChange;
+#endif
 
     MoreNiceGfx = sdl_ButtonBankNew(&PopUp.buttons);
     button = sdl_ButtonBankGet(&PopUp.buttons, MoreNiceGfx);
@@ -2091,6 +2148,8 @@ static errr load_prefs(void)
             tile_width = atoi(s);
         else if (strstr(buf, "TileHeight"))
             tile_height = atoi(s);
+        else if (strstr(buf, "Volume"))
+            volume = atoi(s);
     }
 
     if (screen_w < MIN_SCREEN_WIDTH) screen_w = MIN_SCREEN_WIDTH;
@@ -2211,6 +2270,7 @@ static errr save_prefs(void)
     file_putf(fff, "Graphics = %d\n", use_graphics);
     file_putf(fff, "TileWidth = %d\n", tile_width);
     file_putf(fff, "TileHeight = %d\n", tile_height);
+    file_putf(fff, "Volume = %d\n", volume);
 
     for (i = 0; i < ANGBAND_TERM_MAX; i++)
     {
@@ -3891,6 +3951,12 @@ static void init_sdl_local(void)
     path_build(path, sizeof(path), ANGBAND_DIR_ICONS, "att-128.png");
     if (file_exists(path))
         mratt = IMG_Load(path);
+
+#ifdef SOUND_SDL
+    /* Set global volume */
+    struct sound_config* sound = get_sound_config();
+    sound->volume = volume;
+#endif
 }
 
 

--- a/src/client/snd-sdl.c
+++ b/src/client/snd-sdl.c
@@ -65,6 +65,22 @@ typedef struct
 static bool use_init = false;
 
 
+struct sound_config* get_sound_config() {
+    static struct sound_config config;
+    return &config;
+}
+
+
+int set_volume(int volume) {
+    if (volume < 0) volume = 0;
+    if (volume > 100) volume = 100;
+
+    /* Set all channels to volume */
+    Mix_Volume(-1, (volume * MIX_MAX_VOLUME) / 100);
+    return volume;
+}
+
+
 /*
  * Initialize SDL and open the mixer.
  */
@@ -92,6 +108,10 @@ static bool open_audio_sdl(void)
         plog_fmt("Couldn't open mixer: %s", SDL_GetError());
         return false;
     }
+
+    /* Set initial volume */
+    int volume = get_sound_config()->volume;
+    set_volume(volume);
 
     /* Success */
     return true;
@@ -283,4 +303,4 @@ errr init_sound_sdl(struct sound_hooks *hooks)
 }
 
 
-#endif /* USE_SDL */
+#endif /* USE_SDL */

--- a/src/client/snd-win.c
+++ b/src/client/snd-win.c
@@ -49,6 +49,17 @@ typedef struct
 } win_sample;
 
 
+struct sound_config* get_sound_config() {
+    // Not used 
+    return NULL;
+}
+
+
+int set_volume(int volume) {
+    return volume;
+}
+
+
 static bool open_audio_win(void)
 {
     return true;

--- a/src/client/sound.h
+++ b/src/client/sound.h
@@ -45,7 +45,23 @@ struct sound_hooks
     bool (*play_sound_hook)(struct sound_data *data);
 };
 
+struct sound_config
+{
+    int volume;
+};
+
 extern errr init_sound(void);
 extern errr register_sound_pref_parser(struct parser *p);
+
+/*
+ * Return static variable of sound config
+ */
+extern struct sound_config* get_sound_config(void);
+
+/*
+ * Set volume in %
+ * Return actually volume % was set
+ */
+extern int set_volume(int);
 
 #endif /* INCLUDED_SOUND_H */


### PR DESCRIPTION
I added an ability to change the volume in options in the game (in percents). This is a useful feature when you don't need to set up the system mixer. It works only with SDL. The set volume is saved in `sdlinit.txt` with a key `Volume`. I took care  that this doesn't cause problems for clients without SDL. I tested it only on Linux, but it should work anywhere. If there are any problems, I'll fix that.

A slight implementation complication is that the user settings file is read in the graphics system, but it loads before the sound. Therefore, you cannot immediately set the mixer value. To initialize the volume I use the global variable that can be obtained from the `get_sound_config` function declared in the `sound.h` header. When the sound system is loaded, it reads this value and sets the volume in SDL mixer. Perhaps this is not the best design, but I couldn't find a more suitable and simple solution.