### PR TITLE
Fix do_animate_player() check overflow s_obj[a][nc]

### DIFF
--- a/src/client/ui-display.c
+++ b/src/client/ui-display.c
@@ -2623,6 +2623,9 @@ void do_animate_player(void)
             // Convert char to uint8_t [0 - 255]
             nc = (uint8_t) c;
 
+            // Check for overflow s_obj[1024][256]
+            if (a > 1024 || nc > 256) continue;
+
             // If found then animate
             if (s_obj[a][nc] == 1)
             {


### PR DESCRIPTION
- Fixed bug do_animate_player() array overflow s_obj[1024][256]

> gdb ./pwmangclient
> Thread 1 "pwmangclient" received signal SIGSEGV, Segmentation fault.
> 0x000055555559721f in do_animate_player () at client/ui-display.c:2627

_if player stand on edge of map._
```
// Check characters
Term_info(COL_MAP + j * tile_width, ROW_MAP + i * tile_height, &a, &c, &ta, &tc);
// Convert char to uint8_t [0 - 255]
nc = (uint8_t) c;
```
> nc--->0
> a--->54883
![screen983274](https://user-images.githubusercontent.com/71586060/214595413-ebe40049-b993-4181-9363-ee821a2387ef.jpg)
