### PR TITLE
fix dir_exists on linux

### DIFF
--- a/src/common/z-file.c
+++ b/src/common/z-file.c
@@ -1431,7 +1431,7 @@ bool dir_exists(const char *path)
 	struct stat buf;
 	if (stat(path, &buf) != 0)
 		return false;
-	else if (buf.st_mode & S_IFDIR)
+	else if (S_ISDIR(buf.st_mode))
 		return true;
 	else
 		return false;


### PR DESCRIPTION
This was causing an error `Cannot create '/home/hunner//.pwmangband/Tangaria'` when it already existed and is a simple fix.

It appears that `~` expansion also adds an extra `/`, but that doesn't cause an issue.