### PR TITLE
fix do_slashfx(), do_animations() for SDL1 and Windows clients

### DIFF
--- a/lib/tiles/list.txt
+++ b/lib/tiles/list.txt
@@ -35,4 +35,4 @@ name:1:Tangaria's tileset
 directory:tangaria
 size:32:32:32x32.png
 pref:graf-tan.prf
-extra:1:127:128
+extra:1:0:0

--- a/src/client/main-sdl.c
+++ b/src/client/main-sdl.c
@@ -5648,7 +5648,7 @@ static void sdl_DrawTile(term_window *win, int col, int row, SDL_Rect rc, SDL_Re
                 rc.y -= sfx_r;
                 break;
             }
-            case 2: /* TODO: rc.y -= sfx_r; */ break;
+            case 2: rc.y -= sfx_r; break;
             case 3:
             {
                 rc.x += sfx_r;

--- a/src/client/main-win.c
+++ b/src/client/main-win.c
@@ -996,7 +996,10 @@ static bool init_graphics(int v)
 
         overdraw = mode->overdrawRow;
         overdrawmax = mode->overdrawMax;
-        alphablend = mode->alphablend;
+        // alphablend = mode->alphablend;
+        // Hack -- for drawing tiles (void)((*main_term->pict_hook)
+        // do_animations(), do_slashfx() functions
+        alphablend = 0;
     }
     else
     {
@@ -2013,6 +2016,58 @@ static void Term_pict_win_aux(int x, int y, int n, const uint16_t *ap, const cha
                     /* Only draw if terrain and overlay are different */
                     if ((x1 != x3) || (y1 != y3))
                     {
+                        //// Slash fx effect ////
+                        // do_slashfx()
+                        // sfx_effect
+                        // sfx_dir
+                        //  |1|2|3|
+                        //  |4|5|6|
+                        //  |7|8|9|
+                        if (sfx_effect)
+                        {
+                            int sfx_r;
+
+                            sfx_r = randint1(3);
+                            if (sfx_r == 1) sfx_r = 4;
+                            else if (sfx_r == 2) sfx_r = 6;
+                            else if (sfx_r == 3) sfx_r = 8;
+
+                            switch (sfx_dir)
+                            {
+                                case 1:
+                                {
+                                    x2 -= sfx_r;
+                                    y2 -= sfx_r;
+                                    break;
+                                }
+                                case 2: y2 -= sfx_r; break;
+                                case 3:
+                                {
+                                    x2 += sfx_r;
+                                    y2 -= sfx_r;
+                                    break;
+                                }
+                                case 4: x2 -= sfx_r; break;
+                                case 5: break;
+                                case 6: x2 += sfx_r; break;
+                                case 7:
+                                {
+                                    x2 -= sfx_r;
+                                    y2 += sfx_r;
+                                    break;
+                                }
+                                case 8: y2 += sfx_r; break;
+                                case 9:
+                                {
+                                    x2 += sfx_r;
+                                    y2 += sfx_r;
+                                    break;
+                                }
+                            }
+                            sfx_effect = false;
+                            sfx_dir = 0;
+                        }
+
                         /* Mask out the tile */
                         BitBlt(hdc, x2, y2, tw2, th2, hdcMask, x1, y1, SRCAND);
 
@@ -2039,6 +2094,58 @@ static void Term_pict_win_aux(int x, int y, int n, const uint16_t *ap, const cha
                     /* Only draw if terrain and overlay are different */
                     if ((x1 != x3) || (y1 != y3))
                     {
+                        //// Slash fx effect ////
+                        // do_slashfx()
+                        // sfx_effect
+                        // sfx_dir
+                        //  |1|2|3|
+                        //  |4|5|6|
+                        //  |7|8|9|
+                        if (sfx_effect)
+                        {
+                            int sfx_r;
+
+                            sfx_r = randint1(3);
+                            if (sfx_r == 1) sfx_r = 4;
+                            else if (sfx_r == 2) sfx_r = 6;
+                            else if (sfx_r == 3) sfx_r = 8;
+
+                            switch (sfx_dir)
+                            {
+                                case 1:
+                                {
+                                    x2 -= sfx_r;
+                                    y2 -= sfx_r;
+                                    break;
+                                }
+                                case 2: y2 -= sfx_r; break;
+                                case 3:
+                                {
+                                    x2 += sfx_r;
+                                    y2 -= sfx_r;
+                                    break;
+                                }
+                                case 4: x2 -= sfx_r; break;
+                                case 5: break;
+                                case 6: x2 += sfx_r; break;
+                                case 7:
+                                {
+                                    x2 -= sfx_r;
+                                    y2 += sfx_r;
+                                    break;
+                                }
+                                case 8: y2 += sfx_r; break;
+                                case 9:
+                                {
+                                    x2 += sfx_r;
+                                    y2 += sfx_r;
+                                    break;
+                                }
+                            }
+                            sfx_effect = false;
+                            sfx_dir = 0;
+                        }
+
                         /* Mask out the tile */
                         StretchBlt(hdc, x2, y2, tw2, th2, hdcMask, x1, y1, w1, h1, SRCAND);
 

--- a/src/client/ui-display.c
+++ b/src/client/ui-display.c
@@ -2465,11 +2465,6 @@ void do_animations(void)
     // Check options, if all opt = 0 then don't animate
     if (opt_anim_obj_w == 0 && opt_anim_obj == 0 && opt_anim_npc == 0) return;
 
-#ifndef USE_SDL2
-    // Hack -- SDL and Windows client, disable opt_anim_obj_w
-    if (opt_anim_obj_w != 0) opt_anim_obj_w = 0;
-#endif
-
     // Hack -- if the screen is already icky, ignore this command
     if (player->screen_save_depth) return;
 


### PR DESCRIPTION
- for correct drawing tiles do_slashfx(), do_animations() 
in Windows client `alphablend = 0`